### PR TITLE
Update `nanoq` to verison `0.10.0`. 

### DIFF
--- a/modules/artic/envs/artic.yml
+++ b/modules/artic/envs/artic.yml
@@ -26,7 +26,7 @@ dependencies:
   - requests = 2.28
   - samtools =1.15
   - tqdm =4.64
-  - nanoq=0.9.0
+  - nanoq=0.10.0
   - typer=0.4.1
   - covtobed=1.3.5  # version required, future version may have filters activated by default [warning message]
   - jinja2

--- a/modules/ont/envs/ont.yml
+++ b/modules/ont/envs/ont.yml
@@ -8,4 +8,4 @@ dependencies:
   - minimap2=2.24
   - samtools
   - ivar=1.3.1
-  - nanoq=0.9.0
+  - nanoq=0.10.0

--- a/modules/report/template.html
+++ b/modules/report/template.html
@@ -97,7 +97,7 @@
           <br>
           <b>Bcftools</b>: v1.10.2
           <br>
-          <b>Nanoq</b>: v0.9.1
+          <b>Nanoq</b>: v0.10.0
           <br>
           <b>Covtobed</b>: v1.3.5
         </div>


### PR DESCRIPTION
Seems like the pipeline was using the latest version because a flag was not present in `nanoq v0.9.1` which triggered an error but the requirements were set to the older version.